### PR TITLE
Fix mobile toggle icon alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -228,9 +228,10 @@ If your plugin does not need CSS, delete this file.
     width: 12px !important;
     margin-right: 0 !important;
     margin-top: 0 !important;
-    position: absolute !important; 
+    position: absolute !important;
     left: 5px !important;
-    top: 8px !important;
+    top: 50% !important;
+    transform: translateY(-50%);
     height: auto !important;
 }
 


### PR DESCRIPTION
## Summary
- adjust mobile collapse icon styles so the arrow centers vertically

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_683aff9ac0f883208120a10a6fa548ba