### PR TITLE
Optimize mobile performance and clean up sample scaffolding

### DIFF
--- a/FileGraph.ts
+++ b/FileGraph.ts
@@ -263,8 +263,6 @@ export function buildFileGraph(items: Array<TFile | TFolder>, app: App): FileGra
     // Get plugin instance and settings
     const plugin = (app as any).plugins.getPlugin('mms');
     const ignorePatterns = plugin?.settings?.ignorePatterns || [];
-    console.log('Building graph with ignore patterns:', ignorePatterns);
-
     const graph: FileGraph = {
         nodes: new Map(),
         edges: new Map()
@@ -359,8 +357,6 @@ export function buildFileGraph(items: Array<TFile | TFolder>, app: App): FileGra
             item.parent ? item.parent.path : '/'
         );
     }
-
-    console.log(`Filtered ${ignoredCount} items based on ignore patterns`);
 
     return graph;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "obsidian-folgezettel-browser",
+  "name": "mms-obsidian",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-folgezettel-browser",
+      "name": "mms-obsidian",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- drop leftover sample ribbon, commands, and global listeners so the plugin only registers its real features
- streamline the folgezettel browser React view to avoid repeatedly enumerating vault files and to remove heavy debug logging
- trim verbose console logging in Marimo/open commands and tidy the lockfile metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa2a3cb448320a4f651117a6d2939